### PR TITLE
Add index.android.js and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ Start the app.
 ```bash
 $ react-native run-ios
 ```
+or
+```bash
+$ react-native run-android
+```
 
 # Limitations
-- Tested on iOS devices only, should work on Android devices too.
 - Some features are supported only specific platform only, please consult with the original documentations and issues.

--- a/examples/GoogleMapsExample/index.android.js
+++ b/examples/GoogleMapsExample/index.android.js
@@ -1,0 +1,5 @@
+const { AppRegistry } = require('react-native');
+const Elm = require('./elm');
+const component = Elm.Main.start();
+
+AppRegistry.registerComponent('GoogleMapsExample', () => component);


### PR DESCRIPTION
App works on Android, so this removes the limitation/disclaimer and adds the `index.android.js`-file and alternative run command to let users know it's not just for iOS.