### PR TITLE
Use existing Marker.identifier instead of creating Marker.markerId

### DIFF
--- a/src/Native/NativeUi/MapView.js
+++ b/src/Native/NativeUi/MapView.js
@@ -62,7 +62,7 @@ const _kyasu1$elm_native_ui_maps$Native_NativeUi_MapView = function () {
    * functions for MapView.Marker
    */
   function refMarker(el) {
-    markers[el.props.markerId] = el;
+    markers[el.props.identifier] = el;
   }
 
   function showCallout(markerId) {

--- a/src/NativeUi/MapView/Marker.elm
+++ b/src/NativeUi/MapView/Marker.elm
@@ -21,7 +21,6 @@ module NativeUi.MapView.Marker
         , onDrag
         , onDragEnd
         , ref
-        , markerId
         , showCallout
         , hideCallout
         )
@@ -38,7 +37,7 @@ module NativeUi.MapView.Marker
 @docs onSelect, onDeselect, onCalloutPress, onDragStart, onDrag, onDragEnd
 
 # Methods
-@docs ref, markerId, showCallout, hideCallout
+@docs ref, showCallout, hideCallout
 -}
 
 import Task exposing (Task)
@@ -193,12 +192,6 @@ onDragEnd tagger =
 ref : Property msg
 ref =
     NativeUi.ref Native.NativeUi.MapView.refMarker
-
-
-{-| -}
-markerId : String -> Property msg
-markerId =
-    property "markerId" << Encode.string
 
 
 {-| -}


### PR DESCRIPTION
There's already a prop called `identifier` whose purpose is "[...] to reference this marker at a later date"<sup><a href="https://github.com/airbnb/react-native-maps/blob/b7f33d0/docs/marker.md">*</a></sup>, so it seems unnecessary to create `markerId` for a similar purpose.
I might misunderstand this though?